### PR TITLE
Update deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Prepare NPM manifest
-        uses: actions/github-script@v3.0.0
+        uses: actions/github-script@v7
         with:
           script: |
             const path = require('path')
@@ -30,7 +30,7 @@ jobs:
 
       - name: Define job variables
         id: define-job-variables
-        uses: actions/github-script@v3.0.0
+        uses: actions/github-script@v7
         with:
           script: |
             const path = require('path')
@@ -38,7 +38,7 @@ jobs:
             require(scriptPath)(path.resolve('./package.json'))
 
       - name: Cache npm dependencies
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.define-job-variables.outputs.npm-cache-path }}
           key: npm-${{ hashFiles('package-lock.json') }}
@@ -46,7 +46,7 @@ jobs:
             npm-
 
       - name: Try to restore esy cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4
         with:
           path: ~/.esy # This can grow quickly. Must be following by rm -rf ~/.esy/3/b
           key: source-${{ hashFiles('re/**/index.json') }}
@@ -58,7 +58,7 @@ jobs:
         run: npm ci
 
       - name: Try to restore Cygwin cache
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4
         with:
           path: .cygwin-cache
           # the number is nothing but date and an arbitrary incrementing number. This number is useful to bust the cache
@@ -68,7 +68,7 @@ jobs:
         run: ./package.ps1 -TempDir $(Resolve-Path -Path test-project)
         shell: pwsh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: release
           path: ${{ steps.define-job-variables.outputs.tarball }} 


### PR DESCRIPTION
## Summary

CI was hard-failing because `actions/cache@v3.3.1` and `actions/upload-artifact@v3` are deprecated and now rejected by GitHub. 